### PR TITLE
fix downmigration. add malformed cyphertext test

### DIFF
--- a/migrations.ts
+++ b/migrations.ts
@@ -56,12 +56,12 @@ const migrations: IMigration[] = [
       );
       `,
     down: `
-      drop table ip_call_count;
-      drop table access_token;
-      drop table deletions;
-      drop table data;
-      drop table entities;
-      drop domain pgp_fingerprint;
+      drop table if exists ip_call_count;
+      drop table  if exists access_token;
+      drop table if exists deletions;
+      drop table if exists data;
+      drop table if exists entities;
+      drop domain if exists pgp_fingerprint;
     `,
   },
 ]

--- a/test/data.ts
+++ b/test/data.ts
@@ -254,6 +254,14 @@ describe('Data', () => {
       assert.equal(body.error, 'id not in sequence')
     })
 
+    it('cannot insert malformed cyphertext', async () => {
+      const malformedData = 'ThisIsNotCyphertext'
+      const response = await postData(firstUser.accessToken, malformedData, firstUser.data.length)
+      const body = await response.json()
+      assert.equal(response.status, 400)
+      assert.equal(body.error, 'bad cyphertext format')
+    })
+
     it('should not let too few signatures be passed if passed', async () => {
       const signatures: string[] = []
 


### PR DESCRIPTION
maybe also add test that ensure SQL injection isn't possible here? 
```
      await client.query(
        `
          insert into data
          (fingerprint  ,id  ,cyphertext) values
          ($1           ,$2  ,$3);
        `,
        [fingerprint, newId, cyphertext],
      )
```