### PR TITLE
Improve signature recovery auth compatibility by using Buffer.compare instead of string comparison

### DIFF
--- a/migrations.ts
+++ b/migrations.ts
@@ -125,6 +125,8 @@ const migrations: IMigration[] = [
         alter column did set data type citext;
       `,
     down: `
+      delete from access_token;
+
       alter table entities
         alter column did set data type text;
       alter table data

--- a/migrations.ts
+++ b/migrations.ts
@@ -108,6 +108,37 @@ const migrations: IMigration[] = [
       drop table if exists data_encrypted_indexes;
     `,
   },
+  {
+    name: 'did-casing-compatibility',
+    up: `
+      CREATE EXTENSION IF NOT EXISTS citext;
+
+      alter table data_encrypted_indexes
+        alter column data_did set data type citext;
+      alter table access_token
+        alter column did set data type citext;
+      alter table deletions
+        alter column did set data type citext;
+      alter table data
+        alter column did set data type citext;
+      alter table entities
+        alter column did set data type citext;
+      `,
+    down: `
+      alter table entities
+        alter column did set data type text;
+      alter table data
+        alter column did set data type text;
+      alter table deletions
+        alter column did set data type text;
+      alter table access_token
+        alter column did set data type text;
+      alter table data_encrypted_indexes
+        alter column data_did set data type text;
+
+      drop extension if exists citext;
+    `,
+  },
 ]
 
 export async function up(conf: any, logs: boolean = true) {

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,5 +1,4 @@
 import * as express from 'express'
-import * as EthU from 'ethereumjs-util'
 
 import {
   apiOnly,
@@ -69,10 +68,16 @@ export const tokenRouter = (app: express.Application) => {
           did: didValidator,
           signature: async (name, value) => {
             try {
-              const ethAddress = EthU.bufferToHex(
-                recoverEthAddressFromPersonalRpcSig(body.accessToken, value)
+              const ethAddress = recoverEthAddressFromPersonalRpcSig(
+                body.accessToken,
+                value
               )
-              if (ethAddress !== body.did.replace('did:ethr:', '')) {
+              const reqEthAddress = Buffer.from(
+                body.did.replace('did:ethr:0x', ''),
+                'hex'
+              )
+
+              if (Buffer.compare(ethAddress, reqEthAddress) !== 0) {
                 throw new ClientFacingError('unauthorized', 401)
               }
               return value

--- a/src/routes/data.ts
+++ b/src/routes/data.ts
@@ -1,5 +1,4 @@
 import * as express from 'express'
-import * as EthU from 'ethereumjs-util'
 
 import {
   apiOnly,
@@ -177,10 +176,15 @@ export const dataRouter = (app: express.Application) => {
           return {
             signatures: value.map((s, i) => {
               try {
-                const ethAddress = EthU.bufferToHex(
-                  recoverEthAddressFromPersonalRpcSig(dataDeletionMessage(ids[i]), s)
+                const ethAddress = recoverEthAddressFromPersonalRpcSig(
+                  dataDeletionMessage(ids[i]),
+                  s
                 )
-                if (ethAddress !== did.replace('did:ethr:', '')) {
+                const reqEthAddress = Buffer.from(
+                  did.replace('did:ethr:0x', ''),
+                  'hex'
+                )
+                if (Buffer.compare(ethAddress, reqEthAddress) !== 0) {
                   throw new ClientFacingError(`invalid signature for id: ${ids[i]}`)
                 }
               } catch (err) {

--- a/test/did-casing.ts
+++ b/test/did-casing.ts
@@ -129,31 +129,31 @@ describe('DID Casing Tests', () => {
 
   it(`Should have 1 non-admin entity upon requesting a token for each different casing of the same user (standard, upper, and lower), but end in 2 non-admin entities when the different user requests a token.`, async () => {
     await requestToken(user.standard)
+    await validateToken(user.standard)
     let entitiesCountQueryRes = await client.query(
       `select count(did) from entities where admin = 'f'`
     )
-    await validateToken(user.standard)
     assert.strictEqual(parseInt(entitiesCountQueryRes.rows[0].count, 10), 1)
 
     await requestToken(user.uppercased)
+    await validateToken(user.uppercased)
     entitiesCountQueryRes = await client.query(
       `select count(did) from entities where admin = 'f'`
     )
-    await validateToken(user.uppercased)
     assert.strictEqual(parseInt(entitiesCountQueryRes.rows[0].count, 10), 1)
 
     await requestToken(user.lowercased)
+    await validateToken(user.lowercased)
     entitiesCountQueryRes = await client.query(
       `select count(did) from entities where admin = 'f'`
     )
-    await validateToken(user.lowercased)
     assert.strictEqual(parseInt(entitiesCountQueryRes.rows[0].count, 10), 1)
 
     await requestToken(user.different)
+    await validateToken(user.different)
     entitiesCountQueryRes = await client.query(
       `select count(did) from entities where admin = 'f'`
     )
-    await validateToken(user.different)
     assert.strictEqual(parseInt(entitiesCountQueryRes.rows[0].count, 10), 2)
   })
 

--- a/test/did-casing.ts
+++ b/test/did-casing.ts
@@ -5,17 +5,13 @@ require('dotenv').config({
     typeof process.env.TEST_ENV === 'string' ? process.env.TEST_ENV : '../.env.test'
   ),
 })
-console.log('ALLOW_ANONYMOUS=' + process.env.ALLOW_ANONYMOUS)
+
 import * as assert from 'assert'
 import fetch from 'node-fetch'
 import {Client} from 'pg'
-// import {ByteSource} from 'aes-js'
-// import {v4 as uuidv4} from 'uuid'
-
 import {up, down} from '../migrations'
 import * as db from '../database'
-// import {dataDeletionMessage, udefCoalesce, personalSign} from '../src/utils'
-import {getRandomKey /*, encryptAES, decryptAES*/} from './utls/aes'
+import {getRandomKey} from './utls/aes'
 import {personalSign} from '../src/utils'
 
 const url = 'http://localhost:3001'
@@ -51,16 +47,6 @@ async function validateToken(user: TUser) {
   })
   return response.json()
 }
-
-// async function getMe(token: string) {
-//   const response = await fetch(`${url}/data/me`, {
-//     headers: {
-//       'Content-Type': 'application/json',
-//       Authorization: `Bearer ${token}`,
-//     },
-//   })
-//   return response.json()
-// }
 
 describe('DID Casing Tests', () => {
   let client: Client
@@ -127,7 +113,7 @@ describe('DID Casing Tests', () => {
     await client.end()
   })
 
-  it(`Should have 1 non-admin entity upon requesting a token for each different casing of the same user (standard, upper, and lower), but end in 2 non-admin entities when the different user requests a token.`, async () => {
+  it(`Should have 1 non-admin entity upon requesting a token for each different casing of the same user (standard, upper, and lower), but end up with 2 non-admin entities when the different user requests a token.`, async () => {
     await requestToken(user.standard)
     await validateToken(user.standard)
     let entitiesCountQueryRes = await client.query(
@@ -156,6 +142,4 @@ describe('DID Casing Tests', () => {
     )
     assert.strictEqual(parseInt(entitiesCountQueryRes.rows[0].count, 10), 2)
   })
-
-  // TODO: ADD SOME data_encrypted_indexes and think about down migration with casing in mind...
 })

--- a/test/did-casing.ts
+++ b/test/did-casing.ts
@@ -1,0 +1,161 @@
+import * as path from 'path'
+require('dotenv').config({
+  path: path.join(
+    __dirname,
+    typeof process.env.TEST_ENV === 'string' ? process.env.TEST_ENV : '../.env.test'
+  ),
+})
+console.log('ALLOW_ANONYMOUS=' + process.env.ALLOW_ANONYMOUS)
+import * as assert from 'assert'
+import fetch from 'node-fetch'
+import {Client} from 'pg'
+// import {ByteSource} from 'aes-js'
+// import {v4 as uuidv4} from 'uuid'
+
+import {up, down} from '../migrations'
+import * as db from '../database'
+// import {dataDeletionMessage, udefCoalesce, personalSign} from '../src/utils'
+import {getRandomKey /*, encryptAES, decryptAES*/} from './utls/aes'
+import {personalSign} from '../src/utils'
+
+const url = 'http://localhost:3001'
+
+type TUser = {
+  privateKey: string
+  did: string
+  accessToken: string
+}
+
+async function requestToken(user: TUser, initialize: boolean = false) {
+  const response = await fetch(
+    `${url}/auth/request-token?did=${user.did}&initialize=${initialize}`,
+    {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+    }
+  )
+  const body = await response.json()
+  user.accessToken = body.token
+  return body
+}
+
+async function validateToken(user: TUser) {
+  const response = await fetch(`${url}/auth/validate-token`, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({
+      accessToken: user.accessToken,
+      signature: personalSign(user.accessToken, user.privateKey),
+      did: user.did,
+    }),
+  })
+  return response.json()
+}
+
+// async function getMe(token: string) {
+//   const response = await fetch(`${url}/data/me`, {
+//     headers: {
+//       'Content-Type': 'application/json',
+//       Authorization: `Bearer ${token}`,
+//     },
+//   })
+//   return response.json()
+// }
+
+describe('DID Casing Tests', () => {
+  let client: Client
+  const privateKey =
+    '0xbc37e4fef90096ea38ec859fa67cf29bf6bf63d099ba345c134c915d1cfbf3b5'
+  const address = '062de159DFA582245712deFCaea2FCd2dCaA3B55'
+  const aesKey = getRandomKey()
+
+  const user = {
+    admin: {
+      aesKey: getRandomKey(),
+      did: `did:ethr:0x686669c5cC1c60352253637787787f6a022ABEa2`,
+      privateKey: `0xd79e484cfd962bd26cd194ee185663c74b52cf841f69b7eafeb27ed46c22d44e`,
+      accessToken: '',
+    },
+    different: {
+      aesKey: getRandomKey(),
+      did: `did:ethr:0x2aA9c9139f9Efb53019D75Dc6d5b2c0a7f50722f`,
+      privateKey:
+        '0xb4e988f0637edc258fe9b2304c11f6af433dc281482322d160d239be880995be',
+      accessToken: '',
+    },
+
+    // should be same user
+    standard: {
+      aesKey,
+      did: `did:ethr:0x${address}`,
+      privateKey,
+      accessToken: '',
+    },
+    uppercased: {
+      aesKey,
+      did: `did:ethr:0x${address.toUpperCase()}`,
+      privateKey,
+      accessToken: '',
+    },
+    lowercased: {
+      aesKey,
+      did: `did:ethr:0x${address.toLowerCase()}`,
+      privateKey,
+      accessToken: '',
+    },
+  }
+
+  before(async () => {
+    client = new Client(db.mocha)
+    await client.connect()
+    await down(db.mocha, true)
+    await up(db.mocha, true)
+
+    // Sets ALLOW_ANONYMOUS to true so the tests can focus on casing differences
+    await requestToken(user.admin, true)
+    await validateToken(user.admin)
+    await fetch(`${url}/debug/set-env/ALLOW_ANONYMOUS/true`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${user.admin.accessToken}`,
+      },
+    })
+  })
+
+  after(async () => {
+    await client.end()
+  })
+
+  it(`Should have 1 non-admin entity upon requesting a token for each different casing of the same user (standard, upper, and lower), but end in 2 non-admin entities when the different user requests a token.`, async () => {
+    await requestToken(user.standard)
+    let entitiesCountQueryRes = await client.query(
+      `select count(did) from entities where admin = 'f'`
+    )
+    await validateToken(user.standard)
+    assert.strictEqual(parseInt(entitiesCountQueryRes.rows[0].count, 10), 1)
+
+    await requestToken(user.uppercased)
+    entitiesCountQueryRes = await client.query(
+      `select count(did) from entities where admin = 'f'`
+    )
+    await validateToken(user.uppercased)
+    assert.strictEqual(parseInt(entitiesCountQueryRes.rows[0].count, 10), 1)
+
+    await requestToken(user.lowercased)
+    entitiesCountQueryRes = await client.query(
+      `select count(did) from entities where admin = 'f'`
+    )
+    await validateToken(user.lowercased)
+    assert.strictEqual(parseInt(entitiesCountQueryRes.rows[0].count, 10), 1)
+
+    await requestToken(user.different)
+    entitiesCountQueryRes = await client.query(
+      `select count(did) from entities where admin = 'f'`
+    )
+    await validateToken(user.different)
+    assert.strictEqual(parseInt(entitiesCountQueryRes.rows[0].count, 10), 2)
+  })
+
+  // TODO: ADD SOME data_encrypted_indexes and think about down migration with casing in mind...
+})


### PR DESCRIPTION
**Changes**
- Change eth address comparison from string based to buffer based since for hex strings the casing is irrelevant. Ethereum uses casing for checksums and we're planning to move the SDK clients to that soon, but we are where we are and this is a compatible middle ground.
- Adds migration that moves backing `did` column from `text` to `citext`. The migration is intentionally simple and doesn't mess around with data. I'm going to do some analysis / manual cleanup tomorrow in staging and production, but since the bloom-vault isn't heavily used we're in a good spot to be able to handle this fairly cleanly.
- Adds some tests that show standard, uppercase, and lowercase formatted `did` strings that represent the same user and verifies that only 1 user (`entities` table) is created for these three different formats.