### PR TITLE
Update type conversion of columns that were changed from text to citext

### DIFF
--- a/test/auth.ts
+++ b/test/auth.ts
@@ -378,7 +378,7 @@ describe('Auth', async () => {
 
               it('should have created the access token', async () => {
                 const result = await client.query(
-                  `select count(*) from access_token where did = $1::text;`,
+                  `select count(*) from access_token where did = $1::citext;`,
                   [friendDid]
                 )
                 assert.strictEqual(result.rows[0].count, '1')
@@ -413,7 +413,7 @@ describe('Auth', async () => {
               assert.strictEqual(badResponse.status, 401)
 
               const result = await client.query(
-                `select count(*) from entities where did = $1::text;`,
+                `select count(*) from entities where did = $1::citext;`,
                 [did]
               )
 


### PR DESCRIPTION
## Ultimate Problem
We changed the `did` columns to be `citext` instead of `text` to work regardless of casing but we still had `::text` type conversions in the queries. I tested this locally and you can't select a row based on `citext` column if you do `::text`

## Solution
- Update type conversions to `::citext`